### PR TITLE
feat: add show folder also select specify file

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,0 +1,49 @@
+use std::fs;
+use std::fs::metadata;
+use std::path::PathBuf;
+use std::process::Command;
+
+#[tauri::command]
+pub async fn show_in_folder(path: String) {
+    #[cfg(target_os = "windows")]
+    {
+        Command::new("explorer")
+            .args(["/select,", &path]) // The comma after select is not a typo
+            .spawn()
+            .unwrap();
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        if path.contains(",") {
+            // see https://gitlab.freedesktop.org/dbus/dbus/-/issues/76
+            let new_path = match metadata(&path).unwrap().is_dir() {
+                true => path,
+                false => {
+                    let mut path2 = PathBuf::from(path);
+                    path2.pop();
+                    path2.into_os_string().into_string().unwrap()
+                }
+            };
+            Command::new("xdg-open").arg(&new_path).spawn().unwrap();
+        } else {
+            Command::new("dbus-send")
+                .args([
+                    "--session",
+                    "--dest=org.freedesktop.FileManager1",
+                    "--type=method_call",
+                    "/org/freedesktop/FileManager1",
+                    "org.freedesktop.FileManager1.ShowItems",
+                    format!("array:string:\"file://{path}\"").as_str(),
+                    "string:\"\"",
+                ])
+                .spawn()
+                .unwrap();
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        Command::new("open").args(["-R", &path]).spawn().unwrap();
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -7,6 +7,7 @@ use tauri_plugin_autostart::MacosLauncher;
 use window_shadows::set_shadow;
 
 mod tray;
+mod commands;
 
 fn main() {
     tauri::Builder::default()
@@ -31,6 +32,7 @@ fn main() {
             window.unminimize().unwrap();
             window.set_focus().unwrap();
         }))
+        .invoke_handler(tauri::generate_handler![commands::show_in_folder])
         .on_system_tray_event(tray::handler)
         .run(tauri::generate_context!())
         .expect("error while running tauri application");


### PR DESCRIPTION
`可选PR,打开文件管理器时选中文件`

示例:
```JavaScript
import { invoke } from '@tauri-apps/api/tauri'
import { sep } from '@tauri-apps/api/path'
import { downloadDir } from '@tauri-apps/api/path'

async function open() {
  // console.log('分隔符:', sep)
  await invoke('show_in_folder', {
    // 注意,如果要拼接路径,不同OS的路径分隔符,请使用 sep
    path: (await downloadDir()) + 'a.txt'
  })
}
```

参考引用: https://github.com/tauri-apps/tauri/issues/4062